### PR TITLE
add styling for pitches

### DIFF
--- a/labels.mss
+++ b/labels.mss
@@ -50,6 +50,7 @@
   text-line-spacing: -4;
   text-character-spacing: 0.5;
   text-size: 11;
+  comp-op: overlay; 
   [zoom>=3][scalerank=1],
   [zoom>=4][scalerank=2],
   [zoom>=5][scalerank=3],

--- a/project.xml
+++ b/project.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE Map[]>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="#f8f4f0" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">
+<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="#f8f4f0">
 
 <Parameters>
   <Parameter name="attribution"><![CDATA[Map data © OpenStreetMap contributors]]></Parameter>
   <Parameter name="bounds">-180,-85.0511,180,85.0511</Parameter>
-  <Parameter name="center">-73.98073196411133,40.75892792712664,15</Parameter>
+  <Parameter name="center">-81.70276343822479,41.501289723897955,16</Parameter>
   <Parameter name="format">png8:m=h</Parameter>
   <Parameter name="maxzoom">22</Parameter>
   <Parameter name="minzoom">0</Parameter>
   <Parameter name="name"><![CDATA[OSM Bright 2]]></Parameter>
-  <Parameter name="scale">1</Parameter>
-  <Parameter name="source"><![CDATA[mapbox:///mapbox.mapbox-streets-v4]]></Parameter>
+  <Parameter name="source"><![CDATA[mapbox:///mapbox.mapbox-streets-v42-dev]]></Parameter>
 </Parameters>
 
 <FontSet name="fontset-0">
@@ -31,6 +30,10 @@
   <Font face-name="Open Sans Regular"/>
 </FontSet>
 <Style name="landuse-overlay" filter-mode="first" opacity="0.1">
+  <Rule>
+    <Filter>([class] = 'pitch')</Filter>
+    <PolygonSymbolizer fill="#3eff20" gamma="0.99" />
+  </Rule>
   <Rule>
     <Filter>([class] = 'wood')</Filter>
     <PolygonSymbolizer fill="#66aa44" gamma="0.5" />
@@ -62,46 +65,46 @@
 <Style name="waterway" filter-mode="first">
   <Rule>
     <MaxScaleDenominator>2500</MaxScaleDenominator>
-    <Filter>([type] = 'canal')</Filter>
+    <Filter>([type] = 'stream')</Filter>
     <LineSymbolizer stroke-width="3" stroke="#90b4d8" stroke-linecap="round" />
   </Rule>
   <Rule>
     <MaxScaleDenominator>12500</MaxScaleDenominator>
     <MinScaleDenominator>2500</MinScaleDenominator>
-    <Filter>([type] = 'canal')</Filter>
+    <Filter>([type] = 'stream')</Filter>
     <LineSymbolizer stroke-width="2" stroke="#90b4d8" stroke-linecap="round" />
   </Rule>
   <Rule>
     <MaxScaleDenominator>50000</MaxScaleDenominator>
     <MinScaleDenominator>12500</MinScaleDenominator>
-    <Filter>([type] = 'canal')</Filter>
+    <Filter>([type] = 'stream')</Filter>
     <LineSymbolizer stroke-width="1" stroke="#90b4d8" stroke-linecap="round" />
   </Rule>
   <Rule>
     <MinScaleDenominator>50000</MinScaleDenominator>
-    <Filter>([type] = 'canal')</Filter>
+    <Filter>([type] = 'stream')</Filter>
     <LineSymbolizer stroke="#90b4d8" stroke-linecap="round" stroke-width="0.5" />
   </Rule>
   <Rule>
     <MaxScaleDenominator>2500</MaxScaleDenominator>
-    <Filter>([type] = 'stream')</Filter>
+    <Filter>([type] = 'canal')</Filter>
     <LineSymbolizer stroke-width="3" stroke="#90b4d8" stroke-linecap="round" />
   </Rule>
   <Rule>
     <MaxScaleDenominator>12500</MaxScaleDenominator>
     <MinScaleDenominator>2500</MinScaleDenominator>
-    <Filter>([type] = 'stream')</Filter>
+    <Filter>([type] = 'canal')</Filter>
     <LineSymbolizer stroke-width="2" stroke="#90b4d8" stroke-linecap="round" />
   </Rule>
   <Rule>
     <MaxScaleDenominator>50000</MaxScaleDenominator>
     <MinScaleDenominator>12500</MinScaleDenominator>
-    <Filter>([type] = 'stream')</Filter>
+    <Filter>([type] = 'canal')</Filter>
     <LineSymbolizer stroke-width="1" stroke="#90b4d8" stroke-linecap="round" />
   </Rule>
   <Rule>
     <MinScaleDenominator>50000</MinScaleDenominator>
-    <Filter>([type] = 'stream')</Filter>
+    <Filter>([type] = 'canal')</Filter>
     <LineSymbolizer stroke="#90b4d8" stroke-linecap="round" stroke-width="0.5" />
   </Rule>
   <Rule>
@@ -1335,7 +1338,7 @@
   srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
     <StyleName>country_label_line</StyleName>  </Layer>
 
-<Style name="country_label" filter-mode="first">
+<Style name="country_label" filter-mode="first" comp-op="overlay">
   <Rule>
     <MaxScaleDenominator>12500000</MaxScaleDenominator>
     <Filter>([scalerank] = 3)</Filter>
@@ -2185,6 +2188,10 @@
     <StyleName>road_label</StyleName>  </Layer>
 
 <Layer name="waterway_label"
+  srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+      </Layer>
+
+<Layer name="housenum_label"
   srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
       </Layer>
 

--- a/project.yml
+++ b/project.yml
@@ -1,4 +1,6 @@
 _prefs: 
+  baselayer: ''
+  mapid: skorasaurus.5eb85050
   saveCenter: true
 _properties: 
   bridge: 
@@ -10,19 +12,17 @@ bounds:
   - 180
   - 85.0511
 center: 
-  - -73.98073196411133
-  - 40.75892792712664
-  - 15
+  - -81.70276343822479
+  - 41.501289723897955
+  - 16
 description: ''
 format: "png8:m=h"
 interactivity_layer: ''
 layers: null
 maxzoom: 22
 minzoom: 0
-mtime: 1395955397710
 name: OSM Bright 2
-scale: 1
-source: "mapbox:///mapbox.mapbox-streets-v4"
+source: "mapbox:///mapbox.mapbox-streets-v42-dev"
 styles: 
   - style.mss
   - road.mss

--- a/style.mss
+++ b/style.mss
@@ -102,6 +102,8 @@ Map {
     // Landuse classes look better as a transparent overlay.
     opacity: 0.1;
     [class='wood'] { polygon-fill: #6a4; polygon-gamma: 0.5; }
+    [class='pitch'] {polygon-fill: #3eff20; polygon-gamma: 0.99; }
+
   }
 }
 


### PR DESCRIPTION
I've been playing around with osm-bright.tm2 so thought to add some pitches to it as well. 

I followed the practice of making it as a transparent overlay as done with the forest cover. 

In the following examples, they are overlaid the park landuse. 
![z14](https://cloud.githubusercontent.com/assets/955351/2609817/c22c7ae8-bb7b-11e3-9fdc-18910d828588.png)
![z16](https://cloud.githubusercontent.com/assets/955351/2609818/c233732a-bb7b-11e3-828e-98ce0dd19f43.png)



here's some examples: