### PR TITLE
drop superfluous zoom filters

### DIFF
--- a/labels.mss
+++ b/labels.mss
@@ -186,7 +186,7 @@
   text-halo-radius: 1;
   text-halo-rasterizer: fast;
   text-size: 10;
-  [type='city'][zoom>=8][zoom<=15] {
+  [type='city'] {
   	text-face-name: @sans_md;
     text-size: 16;
     [zoom>=10] { 


### PR DESCRIPTION
The `[zoom<=15]` actually made the `hide at largest scales` part a few lines below ineffective.